### PR TITLE
SN Include SupplementaryFile in file_types

### DIFF
--- a/portal_objects/file_format.yaml
+++ b/portal_objects/file_format.yaml
@@ -8,6 +8,8 @@ name: zip
 extension: zip
 description: Archive file format that supports lossless data compression
 uuid: 1125243b-3acd-4793-9264-4abd7d788e58
+file_types:
+  - SupplementaryFile
 
 ---
 

--- a/portal_objects/file_format.yaml
+++ b/portal_objects/file_format.yaml
@@ -198,6 +198,7 @@ file_types:
   - ReferenceFile
   - AlignedReads
   - UnalignedReads
+  - SupplementaryFile
 
 ---
 
@@ -213,6 +214,7 @@ file_types:
   - OutputFile
   - ReferenceFile
   - AlignedReads
+  - SupplementaryFile
 
 ---
 
@@ -316,6 +318,8 @@ secondary_formats:
   - dict
   - fa_fai
 uuid: 5ced774b-a73e-4d1b-8186-d7fbbde7a3c2
+file_types:
+  - SupplementaryFile
 
 ---
 
@@ -347,6 +351,7 @@ file_types:
   - OutputFile
   - ReferenceFile
   - VariantCalls
+  - SupplementaryFile
 
 ---
 
@@ -388,6 +393,7 @@ file_types:
   - OutputFile
   - ReferenceFile
   - VariantCalls
+  - SupplementaryFile
 
 ---
 
@@ -449,6 +455,8 @@ extension: bed
 description: BED (Browser Extensible Data) format is a text file format |
              used to store genomic regions as coordinates and associated annotations
 uuid: 4c04f6de-89a7-4477-8dc4-811b50c67401
+file_types:
+  - SupplementaryFile
 
 ---
 
@@ -518,6 +526,8 @@ extension: chain.gz
 description: Format used to represent pairwise alignment that allow gaps in both sequences simultaneously, |
              compressed
 uuid: dd1ef82d-da5e-4680-bd5c-cf471a87eb5b
+file_types:
+  - SupplementaryFile
 
 ---
 


### PR DESCRIPTION
Adds SupplementaryFile to `file_types` for `vcf`, `bam`, `vcf_gz`, `bed`, `cram`, `fa`, and `chain`